### PR TITLE
feat: migrate GPIO abstraction from libgpiod v1 to v2.2.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,9 @@ if(ROCKPI)
     )
     set(EXTRA_LIBS ${MRAA_LIBRARIES})
 else()
-    pkg_search_module(GPIOD REQUIRED libgpiod)
-    pkg_search_module(GPIODCXX REQUIRED libgpiodcxx)
+    pkg_check_modules(GPIOD REQUIRED libgpiod>=2.0)
+    pkg_check_modules(GPIODCXX REQUIRED libgpiodcxx>=2.0)
+    include_directories(${GPIODCXX_INCLUDE_DIRS})
     set(indi_wmh_focuser_SRCS
         wmh_focuser.cpp
         gpiomotor.cpp

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ First, let's install some build tools, if you haven't already.
 sudo apt install build-essential cmake libgpiod-dev
 ```
 
+**Note:** This project requires **libgpiod v2.2+** (available in Debian Trixie and later). The user running `indiserver` needs access to `/dev/gpiochip*` devices. On most distributions, add your user to the `gpio` group:
+```
+sudo usermod -aG gpio $USER
+```
+Then log out and back in for the group change to take effect.
+
 If you built INDI from source, you can skip this step. Otherwise, you must install the INDI development libraries.
 ```
 sudo apt install libindi-dev

--- a/gpiomotor.cpp
+++ b/gpiomotor.cpp
@@ -1,76 +1,111 @@
 #include "gpiomotor.h"
+#include <iostream>
 
 using namespace std;
 
-GpioMotor::GpioMotor(const string& consumer, 
-        const string& enableChip, int enablePin, 
-        const string& directionChip, int directionPin, 
+filesystem::path GpioMotor::chipNameToPath(const string& name)
+{
+    if (!name.empty() && name[0] == '/')
+        return filesystem::path(name);
+    return filesystem::path("/dev") / name;
+}
+
+gpiod::line_request GpioMotor::requestOutputLine(
+    const string& chipName, int pin, const string& consumer)
+{
+    gpiod::line_settings settings;
+    settings.set_direction(gpiod::line::direction::OUTPUT);
+
+    return gpiod::chip(chipNameToPath(chipName))
+        .prepare_request()
+        .set_consumer(consumer)
+        .add_line_settings(gpiod::line::offset(pin), settings)
+        .do_request();
+}
+
+GpioMotor::GpioMotor(const string& consumer,
+        const string& enableChip, int enablePin,
+        const string& directionChip, int directionPin,
         const string& stepChip, int stepPin)
+    : _enablePin(enablePin), _directionPin(directionPin), _stepPin(stepPin)
 {
-    _enableChip.open(enableChip);
-    _directionChip.open(directionChip);
-    _stepChip.open(stepChip);
+    try {
+        _enableRequest.emplace(requestOutputLine(enableChip, enablePin, consumer));
+    } catch (const exception& e) {
+        cerr << "GpioMotor: failed to request enable line (chip="
+             << enableChip << " pin=" << enablePin << "): " << e.what() << endl;
+    }
 
-    if (_enableChip)    _enableLine     = _enableChip.get_line(enablePin);
-    if (_directionChip) _directionLine  = _directionChip.get_line(directionPin);
-    if (_stepChip)      _stepLine       = _stepChip.get_line(stepPin);
+    try {
+        _directionRequest.emplace(requestOutputLine(directionChip, directionPin, consumer));
+    } catch (const exception& e) {
+        cerr << "GpioMotor: failed to request direction line (chip="
+             << directionChip << " pin=" << directionPin << "): " << e.what() << endl;
+    }
 
-    gpiod::line_request request
-    {
-        .consumer = consumer,
-        .request_type = gpiod::line_request::DIRECTION_OUTPUT
-    };
-
-    if (_enableLine)    _enableLine.request(request);
-    if (_directionLine) _directionLine.request(request);
-    if (_stepLine)      _stepLine.request(request);
+    try {
+        _stepRequest.emplace(requestOutputLine(stepChip, stepPin, consumer));
+    } catch (const exception& e) {
+        cerr << "GpioMotor: failed to request step line (chip="
+             << stepChip << " pin=" << stepPin << "): " << e.what() << endl;
+    }
 }
-	
-GpioMotor::~GpioMotor()
-{
-}
-	
+
+GpioMotor::~GpioMotor() = default;
+
 void GpioMotor::Enable(Direction dir)
 {
-    if (_revision == BoardRevision::Rev21)
-        _enableLine.set_value (1);
-    else
-        _enableLine.set_value (0);
-        
-    if (dir == Direction::Forward)
-        _directionLine.set_value (0);
-    else
-        _directionLine.set_value (1);
+    if (_enableRequest) {
+        if (_revision == BoardRevision::Rev21)
+            _enableRequest->set_value(_enablePin, gpiod::line::value::ACTIVE);
+        else
+            _enableRequest->set_value(_enablePin, gpiod::line::value::INACTIVE);
+    }
+
+    if (_directionRequest) {
+        if (dir == Direction::Forward)
+            _directionRequest->set_value(_directionPin, gpiod::line::value::INACTIVE);
+        else
+            _directionRequest->set_value(_directionPin, gpiod::line::value::ACTIVE);
+    }
 }
 
 void GpioMotor::Disable()
 {
-    if (_revision == BoardRevision::Rev21)
-        _enableLine.set_value (0);
-    else
-        _enableLine.set_value (1);
+    if (_enableRequest) {
+        if (_revision == BoardRevision::Rev21)
+            _enableRequest->set_value(_enablePin, gpiod::line::value::INACTIVE);
+        else
+            _enableRequest->set_value(_enablePin, gpiod::line::value::ACTIVE);
+    }
 }
 
 void GpioMotor::SingleStep(int stepDelayMicroseconds)
 {
-    _stepLine.set_value (1);
-    _Delay (stepDelayMicroseconds);
-    _stepLine.set_value (0);
-    _Delay (stepDelayMicroseconds);
+    if (_stepRequest) {
+        _stepRequest->set_value(_stepPin, gpiod::line::value::ACTIVE);
+        _Delay(stepDelayMicroseconds);
+        _stepRequest->set_value(_stepPin, gpiod::line::value::INACTIVE);
+        _Delay(stepDelayMicroseconds);
+    }
 }
 
-//figure out what the chip name should be for Raspberry Pi
-//for Pi5 it should be gpiochip4; otherwise it should be gpiochip0
-//the chip.label() should return something like 'pinctrl_xxx', so we'll use that to detect
+// Figure out what the chip name should be for Raspberry Pi.
+// For Pi5 it should be gpiochip4; otherwise it should be gpiochip0.
+// The chip label should return something like 'pinctrl_xxx', so we use that to detect.
 string GpioMotor::getPiChip()
 {
-    static std::string piChip;
+    static string piChip;
     if (piChip.empty()) {
         piChip = "gpiochip0";
-        for (auto& it: ::gpiod::make_chip_iter()) {
-            string substr = "pinctrl";
-            if (strncmp(it.label().c_str(), substr.c_str(), substr.size())==0) {
-                piChip = it.name();
+        for (const auto& entry : filesystem::directory_iterator("/dev/")) {
+            if (gpiod::is_gpiochip_device(entry.path())) {
+                gpiod::chip chip(entry.path());
+                auto info = chip.get_info();
+                string label = info.label();
+                if (label.rfind("pinctrl", 0) == 0) {
+                    piChip = info.name();
+                }
             }
         }
     }

--- a/gpiomotor.h
+++ b/gpiomotor.h
@@ -1,23 +1,24 @@
 #pragma once
 
 #include <gpiod.hpp>
-#include <memory>
-#include <cstring>
+#include <optional>
+#include <filesystem>
+#include <string>
 #include "motor.h"
 
 class GpioMotor : public Motor
 {
-    gpiod::chip _enableChip;
-    gpiod::chip _directionChip;
-    gpiod::chip _stepChip;
-    gpiod::line _enableLine;
-    gpiod::line _directionLine;
-    gpiod::line _stepLine;
-    
+    std::optional<gpiod::line_request> _enableRequest;
+    std::optional<gpiod::line_request> _directionRequest;
+    std::optional<gpiod::line_request> _stepRequest;
+    gpiod::line::offset _enablePin;
+    gpiod::line::offset _directionPin;
+    gpiod::line::offset _stepPin;
+
 public:
-    GpioMotor(const std::string& consumer, 
-        const std::string& enableChip, int enablePin, 
-        const std::string& directionChip, int directionPin, 
+    GpioMotor(const std::string& consumer,
+        const std::string& enableChip, int enablePin,
+        const std::string& directionChip, int directionPin,
         const std::string& stepChip, int stepPin);
 
     ~GpioMotor() override;
@@ -25,6 +26,11 @@ public:
     void Enable(Direction dir) override;
     void Disable() override;
     void SingleStep(int stepDelayMicroseconds) override;
-    
+
     static std::string getPiChip();
+
+private:
+    static std::filesystem::path chipNameToPath(const std::string& name);
+    static gpiod::line_request requestOutputLine(
+        const std::string& chipName, int pin, const std::string& consumer);
 };


### PR DESCRIPTION
## Summary

Migrates the GPIO motor control code from the removed libgpiod v1 C++ API to libgpiod v2.2.x, fixing compilation on Debian Trixie / Raspberry Pi OS (aarch64).

This is needed because the **latest Astroberry** release is now based on Debian Trixie, which ships libgpiod 2.2.x exclusively. The v1 C++ API (`gpiod::line`, `gpiod::chip::open()`, `gpiod::make_chip_iter()`, etc.) has been removed entirely, so the driver fails to compile out of the box on a fresh Astroberry install.

## Changes

- **gpiomotor.h / gpiomotor.cpp**: Replaced all v1 types and calls with their v2 equivalents:
  - `gpiod::chip` / `gpiod::line` → `std::optional<gpiod::line_request>` + `gpiod::line::offset`
  - `chip.open()` / `get_line()` / `line.request()` → `chip.prepare_request()` builder chain
  - `line.set_value(int)` → `request.set_value(offset, gpiod::line::value)`
  - `gpiod::make_chip_iter()` → `std::filesystem::directory_iterator` + `gpiod::is_gpiochip_device()`
- **CMakeLists.txt**: Changed `pkg_search_module` to `pkg_check_modules` with `>=2.0` version constraint
- **README.md**: Added note about libgpiod v2.2+ requirement and GPIO device permissions

No changes to `wmh_focuser.cpp`, `motor.h`, or the MRAA backend — the constructor signature and runtime behavior are preserved exactly.

## Transparency note

I am not a C/C++ developer. This migration was done with assistance from an LLM (Claude), with the v2 API calls verified against the upstream libgpiod headers and official examples. The code **compiles cleanly**. I am still waiting for the physical hardware (Waveshare Motor HAT) to arrive for a full functional test, so runtime verification on actual GPIO is pending.

If anyone has the hardware available and could test before this is merged, that would be much appreciated.

## Test plan

- [x] Compiles without errors or warnings on Debian Trixie with libgpiod 2.2.x
- [x] No remaining references to removed v1 API (`gpiod::line`, `make_chip_iter`, etc.)
- [ ] Runtime test on Raspberry Pi with Waveshare Motor HAT (pending hardware)

fixes #6, fixes #9