### PR TITLE
fix: motor disabled mid-move whenever a client connects

### DIFF
--- a/wmh_focuser.cpp
+++ b/wmh_focuser.cpp
@@ -172,7 +172,16 @@ void IndiWMHFocuser::ISGetProperties(const char *dev)
 
     INDI::Focuser::ISGetProperties(dev);
 
-    loadConfig(true, "BOARD_REV");
+    // Load the saved board revision only once at startup. ISGetProperties is
+    // invoked every time any client connects, and reloading the config here
+    // re-dispatches BOARD_REV to ISNewSwitch, whose handler disables the
+    // motor — killing any move in progress while the position counter keeps
+    // running (the motion thread steps open-loop into a disabled driver).
+    if (!_configLoaded)
+    {
+        loadConfig(true, "BOARD_REV");
+        _configLoaded = true;
+    }
 
     // addDebugControl();
     return;
@@ -274,8 +283,13 @@ bool IndiWMHFocuser::ISNewSwitch(const char *dev, const char *name, ISState *sta
             else if (BoardRevisionSP[1].getState() == ISS_ON)
                 _motor->SetBoardRevision(BoardRevision::Rev21);
 
-            _motor->Disable();
-            
+            // Only disable the motor when no move is in progress; the motion
+            // thread disables it itself once the move completes. Disabling
+            // here mid-move silently de-energizes the motor while steps are
+            // still being counted.
+            if (FocusAbsPosNP.getState() != IPS_BUSY)
+                _motor->Disable();
+
             BoardRevisionSP.setState(IPS_OK);
             BoardRevisionSP.apply();
             return true;

--- a/wmh_focuser.h
+++ b/wmh_focuser.h
@@ -41,6 +41,7 @@ class IndiWMHFocuser : public INDI::Focuser
         FocusDirection _dir;
         int _usPerStep;
         bool _reverse;
+        bool _configLoaded = false;
 
         volatile bool _abort;
         std::thread _motionThread;


### PR DESCRIPTION
## Summary

Any INDI client connecting while the focuser is moving silently de-energizes the motor, while the position counter keeps counting. The reported position then runs ahead of the physical one, breaking autofocus until a manual re-sync.

**Repro:** start a long move, then run `indi_getprop` (or open any second client — INDI Web Manager status page, a second KStars, a script) mid-move. The motor stops instantly with no holding torque; the UI counts happily to the target.

**Cause:** `ISGetProperties()` is invoked on every client connection and unconditionally calls `loadConfig(true, "BOARD_REV")`. That re-dispatches the switch to `ISNewSwitch`, whose `BOARD_REV` handler ends in an unconditional `_motor->Disable()`. The motion thread has no way to notice and keeps stepping open-loop into a disabled driver.

## Changes

- **wmh_focuser.cpp / wmh_focuser.h**: Load the `BOARD_REV` config only once at startup (guarded by a `_configLoaded` flag) instead of on every client connection.
- **wmh_focuser.cpp**: In the `BOARD_REV` handler, skip `Disable()` while a move is in progress (`FocusAbsPosNP` busy) — the motion thread disables the motor itself on completion.

## Test plan

- [x] Compiles cleanly on Raspberry Pi (Debian Trixie, libgpiod 2.2.x)
- [x] Repro confirmed before the fix: `indi_getprop` mid-move kills the motor instantly
- [x] After the fix: long moves run to completion with clients connecting mid-move; board revision still restored from saved config on startup
- [x] Changing the board revision while idle still disables the motor as before